### PR TITLE
manage git repo internally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "reference-transmogrifier"
 requires-python = ">=3.9"
 dependencies = [
+    "GitPython",
     "openstacksdk@git+https://github.com/ChameleonCloud/openstacksdk@chameleoncloud/blazar",
     "pydantic",
     "pydantic-extra-types",

--- a/src/reference_transmogrifier/reference_api/__init__.py
+++ b/src/reference_transmogrifier/reference_api/__init__.py
@@ -9,7 +9,9 @@ REGION_NAME_MAP = {
 }
 
 
-def write_reference_repo(repo_dir, cloud_name, node: reference_repo.Node) -> None:
+def write_reference_repo(
+    repo_dir, cloud_name, node: reference_repo.Node
+) -> pathlib.Path:
     repo_path = pathlib.Path(repo_dir)
     node_data_path = repo_path.joinpath(
         "data/chameleoncloud/sites",
@@ -25,3 +27,4 @@ def write_reference_repo(repo_dir, cloud_name, node: reference_repo.Node) -> Non
                 indent=2,
             )
         )
+    return node_data_path


### PR DESCRIPTION
instead of specifying an external reference-repo checkout, this now makes a fresh clone into a tmpdir. if conversion is successfull, it moves the tmpdir to output/reference-repository, ready to be used for a PR.