### PR TITLE
expose boot_mode on node object

### DIFF
--- a/src/reference_transmogrifier/models/inspector/inventory.py
+++ b/src/reference_transmogrifier/models/inspector/inventory.py
@@ -5,6 +5,10 @@ from pydantic import BaseModel, ByteSize, Field, computed_field, field_validator
 from reference_transmogrifier.models.inspector.utils import filter_disks
 
 
+class Boot(BaseModel):
+    current_boot_mode: Optional[str] = None
+
+
 class NetworkInterface(BaseModel):
     name: str
     mac_address: str
@@ -90,7 +94,7 @@ class Inventory(BaseModel):
     disks: List[Disk]
     memory: dict
     system_vendor: SystemVendor
-    boot: dict
+    boot: Boot
     hostname: str
     bmc_mac: Optional[str] = None
 

--- a/src/reference_transmogrifier/models/reference_repo.py
+++ b/src/reference_transmogrifier/models/reference_repo.py
@@ -420,6 +420,7 @@ FPGA_lookup = {
 class Node(BaseModel):
     architecture: Architecture
     bios: Bios
+    boot_mode: Optional[str] = None
     chassis: Chassis
     gpu: GPU = Field(default_factory=lambda: GPU(gpu=False))
     fpga: Optional[FPGA] = None
@@ -616,6 +617,8 @@ class Node(BaseModel):
             humanized_ram_size=f"{idata.extra.memory.total_size_gib} GiB",
         )
         monitoring = Monitoring(wattmeter=False)
+        
+        boot_mode = idata.inventory.boot.current_boot_mode if idata.inventory.boot else None
 
         network_adapters = cls.find_network_adapters(idata.extra.network)
         infiniband = any(nic.interface == "InfiniBand" for nic in network_adapters)
@@ -635,6 +638,7 @@ class Node(BaseModel):
         return cls(
             architecture=arch,
             bios=bios,
+            boot_mode=boot_mode,
             chassis=chassis,
             fpga=fpga,
             gpu=gpu,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -126,4 +126,5 @@ class ReferenceRepoNode(base.BaseTestCase):
             blazar_info, inspection_model
         )
 
-        print(output_node_model.model_dump_json(indent=2))
+        self.assertEqual("uefi", output_node_model.boot_mode)
+


### PR DESCRIPTION
ironic inspector natively fetches boot_mode, as ironic needs it for pxe configuration. We can show it to users in the "detailed" info too.