### PR TITLE
Add prune missing nodes flag (off by default)

### DIFF
--- a/src/reference_transmogrifier/main.py
+++ b/src/reference_transmogrifier/main.py
@@ -101,6 +101,16 @@ def parse_args():
             "repository is preserved."
         ),
     )
+    parser.add_argument(
+        "--prune-missing-nodes",
+        action="store_true",
+        help=(
+            "Remove node JSON files from the reference repository that no longer "
+            "correspond to a node in Ironic for this cloud. This is based on the "
+            "cloud's full current node list, independent of --only-nodes/"
+            "--except-nodes. Off by default."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -247,6 +257,17 @@ def main():
         repo_diff = reference_repo_checkout.index.diff(None, paths=node_json)
         if repo_diff:
             print(f"{node.id}:{node.name}: updated reference data")
+
+    if args.prune_missing_nodes:
+        # Always compare against the cloud's full current node list, not
+        # nodes_to_process, so --only-nodes/--except-nodes runs don't prune
+        # nodes that were simply excluded from this particular run.
+        live_node_uids = {n.id for n in conn.baremetal.nodes()}
+        removed_paths = reference_api.prune_missing_nodes(
+            reference_repo_checkout.working_dir, cloud_name, live_node_uids
+        )
+        for removed_path in removed_paths:
+            print(f"{removed_path.stem}: removed, no longer present in ironic")
 
     print(f"finished conversion, moving data from tmpdir to {final_output_dir}")
     shutil.move(reference_repo_checkout.working_dir, final_output_dir)

--- a/src/reference_transmogrifier/reference_api/__init__.py
+++ b/src/reference_transmogrifier/reference_api/__init__.py
@@ -32,3 +32,27 @@ def write_reference_repo(
         f.write(output_json)
 
     return node_data_path
+
+
+def prune_missing_nodes(
+    repo_dir, cloud_name, live_node_uids
+) -> list[pathlib.Path]:
+    """Remove node JSON files for nodes no longer present in `live_node_uids`.
+
+    Returns the list of removed file paths.
+    """
+    repo_path = pathlib.Path(repo_dir)
+    nodes_dir = repo_path.joinpath(
+        "data/chameleoncloud/sites", cloud_name, "clusters/chameleon/nodes"
+    )
+
+    removed = []
+    if not nodes_dir.exists():
+        return removed
+
+    for node_json_path in nodes_dir.glob("*.json"):
+        if node_json_path.stem not in live_node_uids:
+            node_json_path.unlink()
+            removed.append(node_json_path)
+
+    return removed


### PR DESCRIPTION
Adding an option to remove missing nodes (based on if they aren't in ironic anymore) for when nodes are removed from KVM, makes it easier to remove from our reference data. Keeping it off by default so we don't automatically start running this and having it remove nodes that simply weren't there for a specific run at a site.

We'd still need to be cautious running with this flag to make sure the nodes it's removing are the ones we've dropped from KVM, but at least we just double check the nodes being removed instead of manually going through and removing them all.